### PR TITLE
Fix grammar issues and remove repeated text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Nuveo
-It's a company has a goal process and services automation based in Artificial Inteligence. We are begining new projects and reinforce our teams to build systems will integrate to our Computer Vision/AI plataform
+It's a company having as goal the process and services automation based in Artificial Inteligence. We're starting new projects and reinforcing our teams to build systems that will integrate to our Computer Vision/AI plataform.
 
-Please, if you wish to look opportunity in Sao Paulo, look [here](https://github.com/nuveo/IWantToWorkAtNuveo/blob/master/README_pt.md)
+Please, if you wish to look for opportunity in Sao Paulo, look [here](https://github.com/nuveo/IWantToWorkAtNuveo/blob/master/README_pt.md)
 
-## How I choose a oportunity?
+## How do I choose an oportunity?
 
 - Find an opportunity
 - Send email to talentos@nuveo.ai
@@ -13,15 +13,15 @@ Please, if you wish to look opportunity in Sao Paulo, look [here](https://github
   * LinkedIn
   * Tell us about your skills and experience
 
-## Condições e Benefícios Oferecidos
+## Conditions and benefits offered
 
 - Home Office
 - Regime: PJ if you live in Brazil
-- Período: Integral;
+- Time: Full;
 
-## Vagas Disponíveis
+## Available jobs
 
-We are often looking for talents! Even thow you don't opportunity below, send us email with subject "No opportunity avaliable".
+We are often looking for talents! Even if there's no opportunity below, email us with subject "No opportunity avaliable".
 
 ### Computer Vision/AI/Machine Learning Developer
 - Languages: Python or Golang and C++
@@ -47,54 +47,6 @@ Plus:
 - Pytorch
 - Keras
 - Hevc# Nuveo
-It's a company has a goal process and services automation based in Artificial Intelligence. We are beginning new projects and reinforce our teams to build systems will integrate to our Computer Vision/AI platform
-
-## How I choose a opportunity?
-
-- Find an opportunity
-- Send email to talentos@nuveo.ai
-- Subject: Opportunity title
-- Email content?
-  * Github
-  * LinkedIn
-  * Tell us about your skills and experience
-
-## Condition and benefits
-
-- Home Office
-- Regime: PJ if you live in Brazil
-- Full-time
-
-## Opportunities
-
-We are often looking for talents! Even throw you don't opportunity below, send us email with subject "No opportunity avaliable".
-
-### Computer Vision/AI/Machine Learning Developer
-- Languages: Python or Golang and C++
-- RESTful APIs
-- Tesseract
-- Tensorflow
-- OpenCV
-- Signal Processing
-- Machine Learn
-- AI 
-- Image Pre-Processing
-- OCR
-Plus:
-- RPC, HTTP and/or GRPC 
-- TDD and BDD
-- Broker Message (Rabbitmq, Kafka, etc.)
-- Containers
-- Microservices
-- Deep Learn
-- Numpy
-- Scikit-learn
-- Pandas
-- Pytorch
-- Keras
-- Hevc
-Location:
-Remote
 
 ### Fullstack Developer
 - Languages: Go, Python, Ruby or Javascript/NodeJS


### PR DESCRIPTION
### About grammar

Some of these phrases were not making any sense.

E.g.: 
> "It’s a company has a goal process and services automation."

Would be translated to:
> É uma empresa tem um objetivo automação de serviços e processos.

Another example:
> "Even throw you don’t opportunity below, send us email."

Would be:
> Mesmo jogar você não oportunidades abaixo, envie-nos e-mail.

### About rewritten headers
I saw some titles in Portuguese but clearly the intention of the whole text is to be written in English, so I translated them to English to improve homogeneity.

### About repeated content

Both "how do I choose an oportunity" and Computer Vision job topics were typed twice.

Also, there's more repeated jobs (e.g.: "full stack"), but they have different content so I didn't erase it.